### PR TITLE
Prevent Box Plot from Displaying Outliers if Outliers Aren't Calculated

### DIFF
--- a/src/chart-box.js
+++ b/src/chart-box.js
@@ -25,10 +25,14 @@
             var result = [
                 { field: 'lq', value: this.quartiles[0] },
                 { field: 'med', value: this.quartiles[1] },
-                { field: 'uq', value: this.quartiles[2] },
-                { field: 'lo', value: this.loutlier },
-                { field: 'ro', value: this.routlier }
+                { field: 'uq', value: this.quartiles[2] }
             ];
+            if (this.loutlier !== undefined) {
+                result.push({ field: 'lo', value: this.loutlier});
+            }
+            if (this.routlier !== undefined) {
+                result.push({ field: 'ro', value: this.routlier});
+            }
             if (this.lwhisker !== undefined) {
                 result.push({ field: 'lw', value: this.lwhisker});
             }

--- a/src/header.js
+++ b/src/header.js
@@ -179,7 +179,7 @@
 *             When set to false you can supply any number of values and the box plot will
 *             be computed for you.  Default is false.
 *       showOutliers - Set to true (default) to display outliers as circles
-*       outlierIRQ - Interquartile range used to determine outliers.  Default 1.5
+*       outlierIQR - Interquartile range used to determine outliers.  Default 1.5
 *       boxLineColor - Outline color of the box
 *       boxFillColor - Fill color for the box
 *       whiskerColor - Line color used for whiskers


### PR DESCRIPTION
The Box Plot was still showing outliers even if showOutliers was set to false.  I believe I've fixed this.
