### PR TITLE
Fix Normal Range to Allow 0 as Min Value

### DIFF
--- a/src/chart-line.js
+++ b/src/chart-line.js
@@ -221,7 +221,7 @@
 
             canvasHeight--;
 
-            if (options.get('normalRangeMin') && !options.get('drawNormalOnTop')) {
+            if (options.get('normalRangeMin') !== undefined && !options.get('drawNormalOnTop')) {
                 this.drawNormalRange(canvasLeft, canvasTop, canvasHeight, canvasWidth, rangey);
             }
 
@@ -291,7 +291,7 @@
                     options.get('fillColor'), options.get('fillColor')).append();
             }
 
-            if (options.get('normalRangeMin') && options.get('drawNormalOnTop')) {
+            if (options.get('normalRangeMin') !== undefined && options.get('drawNormalOnTop')) {
                 this.drawNormalRange(canvasLeft, canvasTop, canvasHeight, canvasWidth, rangey);
             }
 


### PR DESCRIPTION
If 0 is entered as the normal range min value, normal range is not drawn, but
it should be. This fix ensures that as long as normalRangeMin is defined, the
normal range will get drawn.
