### PR TITLE
Adding test for document.namespaces for IE10

### DIFF
--- a/src/vcanvas-base.js
+++ b/src/vcanvas-base.js
@@ -1,7 +1,7 @@
     // Setup a very simple "virtual canvas" to make drawing the few shapes we need easier
     // This is accessible as $(foo).simpledraw()
 
-    if ($.browser.msie && !document.namespaces.v) {
+    if ($.browser.msie && document.namespaces && !document.namespaces.v) {
         document.namespaces.add('v', 'urn:schemas-microsoft-com:vml', '#default#VML');
     }
 


### PR DESCRIPTION
The jQuery Sparklines website, and others using the plugin, fail to render properly in IE10 due to the absence of namespaces on the document object. Adding a test for the member prior to using it resolves these issues and permits the sites using this plugin to continue rendering uninterrupted.
