### PR TITLE
Reduce minified size by caching document, Math, & undefined

### DIFF
--- a/src/footer.js
+++ b/src/footer.js
@@ -1,1 +1,3 @@
 }));
+
+})( document, Math );

--- a/src/header.js
+++ b/src/header.js
@@ -202,6 +202,8 @@
 
 /*jslint regexp: true, browser: true, jquery: true, white: true, nomen: false, plusplus: false, maxerr: 500, indent: 4 */
 
+(function( document, Math, undefined ) {
+
 (function(factory) {
     if(typeof define === 'function' && define.amd) {
 		define(['jquery'], factory);


### PR DESCRIPTION
Closure to cache document, Math, undefined -- should result in a very slight performance improvement and smaller minified size.
