### PR TITLE
Added options for reference lines in line-charts.

### DIFF
--- a/src/chart-line.js
+++ b/src/chart-line.js
@@ -342,6 +342,18 @@
                 }
             }
 
+			if (options.get('refLineX')) {
+				var y;
+				y = Math.round(this.canvasHeight - (options.get('refLineX') - this.miny) * (this.canvasHeight/rangey));
+				target.drawLine(0, y, this.canvasWidth, y, options.get('refLineColor')).append();
+			}
+
+			if (options.get('refLineY')) {
+				var x;
+				x = Math.round((options.get('refLineY') - this.minx) * (this.canvasWidth/rangex));
+				target.drawLine(x, this.canvasHeight, x, 0, options.get('refLineColor')).append();
+			}
+
             this.lastShapeId = target.getLastShapeId();
             this.canvasTop = canvasTop;
             target.render();

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -33,6 +33,7 @@
                 spotColor: '#f80',
                 highlightSpotColor: '#5f5',
                 highlightLineColor: '#f22',
+                refLineColor: '#f22',
                 spotRadius: 1.5,
                 minSpotColor: '#f80',
                 maxSpotColor: '#f80',


### PR DESCRIPTION
Added options for refLineX and refLineY which draws a reference
(horizontal/vertical) at corresponding X or Y value - in the color
specified by the option refLineColor (with default value).

Mostly to scratch my own itch. Who ever shares my itch, please help yourself.
