### PR TITLE
Add option **toolTipPosition** to display tooltip to the *left* or *right* of the mouse

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -110,6 +110,7 @@
 *   tooltipSkipNull - If true then null values will not have a tooltip displayed (defaults to true)
 *   tooltipValueLookups - An object or range map to map field values to tooltip strings
 *       (eg. to map -1 to "Lost", 0 to "Draw", and 1 to "Win")
+*   toolTipPosition - Display tooltip to the 'left' or 'right' of the mouse - Defaults to "right"
 *   numberFormatter - Optional callback for formatting numbers in tooltips
 *   numberDigitGroupSep - Character to use for group separator in numbers "1,234" - Defaults to ","
 *   numberDecimalMark - Character to use for the decimal point when formatting numbers - Defaults to "."

--- a/src/interact.js
+++ b/src/interact.js
@@ -148,6 +148,7 @@
             this.container = options.get('tooltipContainer') || document.body;
             this.tooltipOffsetX = options.get('tooltipOffsetX', 10);
             this.tooltipOffsetY = options.get('tooltipOffsetY', 12);
+            this.displayOnLeft  = options.get('toolTipPosition') === 'left';
             // remove any previous lingering tooltip
             $('#jqssizetip').remove();
             $('#jqstooltip').remove();
@@ -179,6 +180,9 @@
 
         getSize: function (content) {
             this.sizetip.html(content).appendTo(this.container);
+            var lpadding = parseInt(this.sizetip.css('padding-left'),10);
+            var rpadding = parseInt(this.sizetip.css('padding-right'),10);
+            this.padding = lpadding + rpadding + 1;
             this.width = this.sizetip.width() + 1;
             this.height = this.sizetip.height();
             this.sizetip.remove();
@@ -220,10 +224,14 @@
             }
 
             y -= this.height + this.tooltipOffsetY;
-            x += this.tooltipOffsetX;
-
             if (y < this.scrollTop) {
                 y = this.scrollTop;
+            }
+
+            if(this.displayOnLeft) {
+                x -= this.tooltipOffsetX + this.width + this.padding;
+            } else {
+                x += this.tooltipOffsetX;
             }
             if (x < this.scrollLeft) {
                 x = this.scrollLeft;


### PR DESCRIPTION
I needed the tooltip to display to the left of the mouse in my layout in order to not go behind another positioned element.

The option: `toolTipPosition: 'left'` can be passed when calling `sparkline()` to place the tooltip to the left of the mouse instead of the right.
