### PR TITLE
Avoid load errors with document.namespaces in IE

### DIFF
--- a/src/simpledraw.js
+++ b/src/simpledraw.js
@@ -4,19 +4,47 @@
         if (useExisting && (target = this.data('_jqs_vcanvas'))) {
             return target;
         }
+        
+        if ($.fn.sparkline.canvas === false)
+        {
+            // We've already determined that neither Canvas nor VML are available
+            return false;
+        }
+        else if ($.fn.sparkline.canvas === undefined)
+        {
+            // No function defined yet -- need to see if we support Canvas or VML
+            var el = document.createElement('canvas');
+            if (!!(el.getContext && el.getContext('2d')))
+            {
+                // Canvas is available
+                $.fn.sparkline.canvas = function(width, height, target, interact) {
+                    return new VCanvas_canvas(width, height, target, interact);
+                };
+            }
+            else if (document.namespaces && !document.namespaces.v) {
+                // VML is available
+                document.namespaces.add('v', 'urn:schemas-microsoft-com:vml', '#default#VML');
+                $.fn.sparkline.canvas = function(width, height, target, interact) {
+                    return new VCanvas_vml(width, height, target);
+                };
+            }
+            else
+            {
+                // Neither Canvas nor VML are available
+                $.fn.sparkline.canvas = false;
+                return false;
+            }
+        }
+
         if (width === undefined) {
             width = $(this).innerWidth();
         }
         if (height === undefined) {
             height = $(this).innerHeight();
         }
-        if ($.fn.sparkline.hasCanvas) {
-            target = new VCanvas_canvas(width, height, this, interact);
-        } else if ($.fn.sparkline.hasVML) {
-            target = new VCanvas_vml(width, height, this);
-        } else {
-            return false;
-        }
+
+        target = $.fn.sparkline.canvas(width, height, this, interact);
+        
         mhandler = $(this).data('_jqs_mhandler');
         if (mhandler) {
             mhandler.registerCanvas(target);

--- a/src/vcanvas-base.js
+++ b/src/vcanvas-base.js
@@ -1,20 +1,6 @@
     // Setup a very simple "virtual canvas" to make drawing the few shapes we need easier
     // This is accessible as $(foo).simpledraw()
 
-    // Detect browser renderer support
-    (function() {
-        if (document.namespaces && !document.namespaces.v) {
-            $.fn.sparkline.hasVML = true;
-            document.namespaces.add('v', 'urn:schemas-microsoft-com:vml', '#default#VML');
-        } else {
-            $.fn.sparkline.hasVML = false;
-        }
-
-        var el = document.createElement('canvas');
-        $.fn.sparkline.hasCanvas = !!(el.getContext && el.getContext('2d'));
-
-    })()
-
     VShape = createClass({
         init: function (target, id, type, args) {
             this.target = target;


### PR DESCRIPTION
Fix for the issue described in https://github.com/gwatts/jquery.sparkline/issues/64
