### PR TITLE
Attempt to fix issues with bootstrap.

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -129,6 +129,11 @@
         };
     };
 
+    // Bootstrap adds box-sizing that messes with alignment in the tooltip.
+    var box-sizing = '-webkit-box-sizing: content-box !important;' +
+          '-moz-box-sizing: content-box !important;' +
+          'box-sizing: content-box !important;'
+
     // You can have tooltips use a css class other than jqstooltip by specifying tooltipClassname
     defaultStyles = '.jqstooltip { ' +
             'position: absolute;' +
@@ -147,10 +152,15 @@
             'border: 1px solid white;' +
             'box-sizing: content-box;' +
             'z-index: 10000;' +
+            box-sizing +
             '}' +
             '.jqsfield { ' +
             'color: white;' +
             'font: 10px arial, san serif;' +
             'text-align: left;' +
-            '}';
+            '}' +
+            '.jqstooltip:before, .jqstooltip:after { ' +
+            box-sizing +
+            '}'
+
 


### PR DESCRIPTION
When running sparklines in an environment with bootstrap 3, the tooltip alignment is messed up due to the box-sizing that bootstrap adds to "*, *:before, *:after", overriding these box-sizing values allows it to work out of the box. I thought it could be useful for someone else, it doesn't change any existing behavior at all.
