### PR TITLE
box-sizing still requires prefix for firefox browsers

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -146,6 +146,7 @@
             'padding: 5px;' +
             'border: 1px solid white;' +
             'box-sizing: content-box;' +
+            '-moz-box-sizing: content-box;' +
             'z-index: 10000;' +
             '}' +
             '.jqsfield { ' +


### PR DESCRIPTION
Still yet to be unprefixed: http://caniuse.com/css3-boxsizing
