### PR TITLE
Simpler method to add css style to page

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -200,25 +200,7 @@
         return $.isArray(val) ? val : [val];
     };
 
-    // http://paulirish.com/2008/bookmarklet-inject-new-css-rules/
     addCSS = function(css) {
-        var tag, iefail;
-        if (document.createStyleSheet) {
-            try {
-                document.createStyleSheet().cssText = css;
-                return;
-            } catch (e) {
-                // IE <= 9 maxes out at 31 stylesheets; inject into page instead.
-                iefail = true;
-            }
-        }
-        tag = document.createElement('style');
-        tag.type = 'text/css';
-        document.getElementsByTagName('head')[0].appendChild(tag);
-        if (iefail) {
-            document.styleSheets[document.styleSheets.length - 1].cssText = css;
-        } else {
-            tag[(typeof document.body.style.WebkitAppearance == 'string') /* webkit only */ ? 'innerText' : 'innerHTML'] = css;
-        }
+        $(document).find('head').append('<style type="text/css">@charset "UTF-8";'+ css +'</style>');
     };
 


### PR DESCRIPTION
This is a simplet method to add css style to the page.

I have an issue when I use Sparkline with Font awesome (or any other font that use css pseudo elements to declare content). The issue is that the content of the font isn't loaded as it should be and thus the icons are not rendered. I've discovered that changing the way Sparkline insert css onto the page resolves the problem. I can show you a simple test case if needed.

Tested on IE8+, Chrome, Firefox.
