### PR TITLE
Fix for line charts with a data gap at the beginning

### DIFF
--- a/src/chart-line.js
+++ b/src/chart-line.js
@@ -246,8 +246,8 @@
                             path = [];
                             paths.push(path);
                         }
-                        vertices.push(null);
                     }
+                    vertices.push(null);
                 } else {
                     if (y < this.miny) {
                         y = this.miny;


### PR DESCRIPTION
![spaklines_defect](https://cloud.githubusercontent.com/assets/11990572/7198100/14ca9522-e4e9-11e4-8b70-9ea318929169.png)

When the values array started with one or more null values, incorrect spot got highlighted on the chart when it was moused over.
