### PR TITLE
Cleanup jQuery event shorthand methods & proxy

### DIFF
--- a/src/interact.js
+++ b/src/interact.js
@@ -24,9 +24,9 @@
             var $canvas = $(canvas.canvas);
             this.canvas = canvas;
             this.$canvas = $canvas;
-            $canvas.on('mouseenter', $.proxy(this.mouseenter, this));
-            $canvas.on('mouseleave', $.proxy(this.mouseleave, this));
-            $canvas.on('click', $.proxy(this.mouseclick, this));
+            $canvas.on('mouseenter', this.mouseenter.bind(this));
+            $canvas.on('mouseleave', this.mouseleave.bind(this));
+            $canvas.on('click', this.mouseclick.bind(this));
         },
 
         reset: function (removeTooltip) {
@@ -46,7 +46,7 @@
 
         mouseenter: function (e) {
             $(document.body).unbind('mousemove.jqs');
-            $(document.body).bind('mousemove.jqs', $.proxy(this.mousemove, this));
+            $(document.body).bind('mousemove.jqs', this.mousemove.bind(this));
             this.over = true;
             this.currentPageX = e.pageX;
             this.currentPageY = e.pageY;
@@ -166,7 +166,7 @@
             this.offsetTop = offset.top;
             this.hidden = true;
             $(window).unbind('resize.jqs scroll.jqs');
-            $(window).bind('resize.jqs scroll.jqs', $.proxy(this.updateWindowDims, this));
+            $(window).bind('resize.jqs scroll.jqs', this.updateWindowDims.bind(this));
             this.updateWindowDims();
         },
 

--- a/src/interact.js
+++ b/src/interact.js
@@ -24,9 +24,9 @@
             var $canvas = $(canvas.canvas);
             this.canvas = canvas;
             this.$canvas = $canvas;
-            $canvas.mouseenter($.proxy(this.mouseenter, this));
-            $canvas.mouseleave($.proxy(this.mouseleave, this));
-            $canvas.click($.proxy(this.mouseclick, this));
+            $canvas.on('mouseenter', $.proxy(this.mouseenter, this));
+            $canvas.on('mouseleave', $.proxy(this.mouseleave, this));
+            $canvas.on('click', $.proxy(this.mouseclick, this));
         },
 
         reset: function (removeTooltip) {


### PR DESCRIPTION
Removed usage of jQuery event shorthand method and proxy since it is marked as deprecated in 3.3.1 onward and will be removed from slim builds eventually