### PR TITLE
docs: Fix simple typo, valuess -> values

### DIFF
--- a/src/chart-line.js
+++ b/src/chart-line.js
@@ -185,7 +185,7 @@
             yvalues = this.yvalues;
 
             if (!this.yminmax.length || this.yvalues.length < 2) {
-                // empty or all null valuess
+                // empty or all null values
                 return;
             }
 


### PR DESCRIPTION
There is a small typo in src/chart-line.js.

Should read `values` rather than `valuess`.

